### PR TITLE
Fallback to more tag if excerpt is not defined in front matter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 var yaml = require('yaml-front-matter');
 
 hexo.extend.filter.register('after_post_render', function(data) {
-	data.excerpt = yaml.loadFront(data.raw).excerpt;
+	var excerpt = yaml.loadFront(data.raw).excerpt;
+	if (excerpt !== undefined){
+		data.excerpt = excerpt;
+	}
 	return data;
 });


### PR DESCRIPTION
Currently, if a excerpt is not defined in front matter, it will simply be empty.
Sometimes, it is still preferable to fallback to the default excerpt extracted by more tag,
