### PR TITLE
Pull excerpt from post content if not defined in front-matter or with --more--

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,11 @@ var yaml = require('yaml-front-matter');
 
 hexo.extend.filter.register('after_post_render', function(data) {
 	var excerpt = yaml.loadFront(data.raw).excerpt;
+	var postExcerpt = data.content.substr(0,200);
 	if (excerpt !== undefined){
 		data.excerpt = excerpt;
+	} else if (postExcerpt !== undefined && (data.excerpt == undefined || data.excerpt.trim().length == 0)){
+		data.excerpt = postExcerpt + "...";
 	}
 	return data;
 });


### PR DESCRIPTION
This is to mimic how excerpts work in Jekyll where they will take the first few characters from the post content if an excerpt isn't defined in the front matter. This will do that as well but only if an excerpt is not defined by `<!--more-->` first.
